### PR TITLE
Update CI test to 1.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         version:
           - "1.7"
-          - "1.9"
+          - "1.10"
           - "nightly"
         os:
           - ubuntu-latest


### PR DESCRIPTION
This pull request updates the CI test to use version 1.10 instead of 1.9. This change ensures that the test is running with the latest version and helps maintain compatibility with the latest dependencies.